### PR TITLE
fix/shellcheck-warnings

### DIFF
--- a/platform/stage/build/application/build.sh
+++ b/platform/stage/build/application/build.sh
@@ -60,6 +60,7 @@ trap cleanup EXIT
 ping -o "${IP:?}" && until ssh "${VPS_SUDO_USER:?}@${IP:?}" exit; do sleep 5; done # wait
 
 rsync --verbose --recursive -e ssh "./upload" "${VPS_SUDO_USER:?}@${IP:?}:${VPS_HOME:?}/"
+# shellcheck disable=SC2087
 ssh "${VPS_SUDO_USER:?}@$IP" bash <<EOF
   set -v -e
   cd "${VPS_HOME:?}/upload"

--- a/platform/stage/build/base/provision.sh
+++ b/platform/stage/build/base/provision.sh
@@ -30,7 +30,7 @@ apt-get install -y tree jq fail2ban openssh-server unattended-upgrades
 # Mapping
 # ---------------------------------------------------------------------------- #
 
-find map -type f | while read FILE; do
+find map -type f | while read -r FILE; do
   sudo mkdir -pv "$(dirname "${FILE/map/}")"
   sudo mv -v "${FILE}" "${FILE/map/}"
 done

--- a/platform/stage/build/database/upload/image.sh
+++ b/platform/stage/build/database/upload/image.sh
@@ -25,52 +25,52 @@ POSTGRES_REGULAR_USER_PASSWD_HASHED="${POSTGRES_REGULAR_USER_PASSWD_HASHED?:}"
 # ------------------------------------------------------------- #
 
 function install-postgresql() {
-    # Source: https://www.postgresql.org/download/linux/ubuntu/
-    # info "Create the file repository configuration"
-    sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-    # info "Import the repository signing key"
-    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-    retry apt-get update
-    retry apt-get install -y postgresql-15
+  # Source: https://www.postgresql.org/download/linux/ubuntu/
+  # info "Create the file repository configuration"
+  sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+  # info "Import the repository signing key"
+  wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+  retry apt-get update
+  retry apt-get install -y postgresql-15
 }
 
 function configure-postgresql() {
-    # info "creating directory: /mnt/server/archivedir"
-    mkdir -p "/mnt/server/archivedir"
-    chown postgres:postgres "/etc/postgresql/13/main/conf.d/logbook.conf"
+  # info "creating directory: /mnt/server/archivedir"
+  mkdir -p "/mnt/server/archivedir"
+  chown postgres:postgres "/etc/postgresql/13/main/conf.d/logbook.conf"
 }
 
 function postgresql-create-user-and-database() {
-    # Source: https://www.digitalocean.com/community/tutorials/how-to-install-postgresql-on-ubuntu-20-04-quickstart
-    adduser --disabled-password --gecos "" "$POSTGRES_USER"
-    sudo -u postgres createuser --createdb --no-superuser --no-createrole --no-replication "$POSTGRES_USER"
-    sudo -u "$POSTGRES_USER" createdb "$POSTGRES_USER"
+  # Source: https://www.digitalocean.com/community/tutorials/how-to-install-postgresql-on-ubuntu-20-04-quickstart
+  adduser --disabled-password --gecos "" "$POSTGRES_USER"
+  sudo -u postgres createuser --createdb --no-superuser --no-createrole --no-replication "$POSTGRES_USER"
+  sudo -u "$POSTGRES_USER" createdb "$POSTGRES_USER"
 }
 
 function restart-postgresql() {
-    systemctl restart postgresql
+  systemctl restart postgresql
 }
 
 function change-postgresql-password() {
-    # source: https://subscription.packtpub.com/book/big_data_and_business_intelligence/9781789537581/1/ch01lvl1sec18/changing-your-password-securely
-    sudo -u "$POSTGRES_USER" psql -c "ALTER USER \"$POSTGRES_USER\" PASSWORD '$POSTGRES_REGULAR_USER_PASSWD_HASHED';"
-    rm "/home/$POSTGRES_USER/.psql_history"
+  # source: https://subscription.packtpub.com/book/big_data_and_business_intelligence/9781789537581/1/ch01lvl1sec18/changing-your-password-securely
+  sudo -u "$POSTGRES_USER" psql -c "ALTER USER \"$POSTGRES_USER\" PASSWORD '$POSTGRES_REGULAR_USER_PASSWD_HASHED';"
+  rm "/home/$POSTGRES_USER/.psql_history"
 }
 
 function configure-ssh() {
-    # info "configuring sshd to allow logins to user $POSTGRES_USER"
-    sed -r "s;^AllowUsers (.*);AllowUsers \1 $POSTGRES_USER;" --in-place /etc/ssh/sshd_config
-    # info "creating ~/.ssh directory, adjusting ownership and privileges"
-    mkdir -p "/home/$POSTGRES_USER/.ssh"
-    chown -R $POSTGRES_USER:$POSTGRES_USER "/home/$POSTGRES_USER"
-    chmod 700 "/home/$POSTGRES_USER"
-    # info "deploy application server's public key to created user's authorized_keys"
-    touch "/home/$POSTGRES_USER/.ssh/authorized_keys"
-    chown -R $POSTGRES_USER:$POSTGRES_USER "/home/$POSTGRES_USER"
-    chmod 700 "/home/$POSTGRES_USER"
-    cat "$PROVISIONER_FILES/ssh-app-db.pub" >>"/home/$POSTGRES_USER/.ssh/authorized_keys"
-    # info "restart sshd.service"
-    systemctl restart sshd
+  # info "configuring sshd to allow logins to user $POSTGRES_USER"
+  sed -r "s;^AllowUsers (.*);AllowUsers \1 $POSTGRES_USER;" --in-place /etc/ssh/sshd_config
+  # info "creating ~/.ssh directory, adjusting ownership and privileges"
+  mkdir -p "/home/$POSTGRES_USER/.ssh"
+  chown -R $POSTGRES_USER:$POSTGRES_USER "/home/$POSTGRES_USER"
+  chmod 700 "/home/$POSTGRES_USER"
+  # info "deploy application server's public key to created user's authorized_keys"
+  touch "/home/$POSTGRES_USER/.ssh/authorized_keys"
+  chown -R $POSTGRES_USER:$POSTGRES_USER "/home/$POSTGRES_USER"
+  chmod 700 "/home/$POSTGRES_USER"
+  cat "$PROVISIONER_FILES/ssh-app-db.pub" >>"/home/$POSTGRES_USER/.ssh/authorized_keys"
+  # info "restart sshd.service"
+  systemctl restart sshd
 }
 
 # ------------------------------------------------------------- #

--- a/platform/stage/build/database/upload/image.sh
+++ b/platform/stage/build/database/upload/image.sh
@@ -67,11 +67,11 @@ function configure-ssh() {
   sed -r "s;^AllowUsers (.*);AllowUsers \1 $POSTGRES_USER;" --in-place /etc/ssh/sshd_config
   # info "creating ~/.ssh directory, adjusting ownership and privileges"
   mkdir -p "/home/$POSTGRES_USER/.ssh"
-  chown -R $POSTGRES_USER:$POSTGRES_USER "/home/$POSTGRES_USER"
+  chown -R "$POSTGRES_USER:$POSTGRES_USER" "/home/$POSTGRES_USER"
   chmod 700 "/home/$POSTGRES_USER"
   # info "deploy application server's public key to created user's authorized_keys"
   touch "/home/$POSTGRES_USER/.ssh/authorized_keys"
-  chown -R $POSTGRES_USER:$POSTGRES_USER "/home/$POSTGRES_USER"
+  chown -R "$POSTGRES_USER:$POSTGRES_USER" "/home/$POSTGRES_USER"
   chmod 700 "/home/$POSTGRES_USER"
   cat "$PROVISIONER_FILES/ssh-app-db.pub" >>"/home/$POSTGRES_USER/.ssh/authorized_keys"
   # info "restart sshd.service"

--- a/platform/stage/build/database/upload/image.sh
+++ b/platform/stage/build/database/upload/image.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+PS4='\033[32m$0:$LINENO\033[0m: '
+set -xe
+
 # TODO: Harden Postgres https://www.cybertec-postgresql.com/en/postgresql-security-things-to-avoid-in-real-life/
 
 # ------------------------------------------------------------- #
@@ -8,7 +11,9 @@
 
 PROVISIONER_FILES="/home/$SUDO_USER/provisioner-files"
 cd "$PROVISIONER_FILES"
+# shellcheck disable=SC1091
 . commons.sh
+# shellcheck disable=SC1091
 . secrets.sh
 
 # ------------------------------------------------------------- #

--- a/platform/stage/build/gateway/build.sh
+++ b/platform/stage/build/gateway/build.sh
@@ -56,6 +56,7 @@ trap cleanup EXIT
 ping -o "${IP:?}" && until ssh "${VPS_SUDO_USER:?}@${IP:?}" exit; do sleep 5; done # wait
 
 rsync --verbose --recursive -e ssh "./upload" "${VPS_SUDO_USER:?}@${IP:?}:${VPS_HOME:?}/"
+# shellcheck disable=SC2087
 ssh "${VPS_SUDO_USER:?}@$IP" bash <<EOF
     set -e
     set -v

--- a/platform/stage/build/gateway/build.sh
+++ b/platform/stage/build/gateway/build.sh
@@ -17,7 +17,6 @@ set -xeuo pipefail
 # ---------------------------------------------------------------------------- #
 
 VPS_HOME="/home/${VPS_SUDO_USER:?}"
-IPTABLES_PUBLIC_ETHERNET_INTERFACE="eth0"
 IPTABLES_PRIVATE_ETHERNET_INTERFACE="eth1"
 
 BASE_IMAGE_PREFIX="build_internal"

--- a/platform/stage/build/internal/build.sh
+++ b/platform/stage/build/internal/build.sh
@@ -58,6 +58,7 @@ trap cleanup EXIT
 ping -o "${IP:?}" && until ssh "${VPS_SUDO_USER:?}@${IP:?}" exit; do sleep 5; done # wait
 
 rsync --verbose --recursive -e ssh "./upload" "${VPS_SUDO_USER:?}@${IP:?}:${VPS_HOME:?}/"
+# shellcheck disable=SC2087
 ssh "${VPS_SUDO_USER:?}@$IP" bash <<EOF
   set -e -v
   cd "${VPS_HOME:?}/upload"

--- a/platform/stage/build/vpn/provision.sh
+++ b/platform/stage/build/vpn/provision.sh
@@ -32,7 +32,7 @@ test -d /etc/openvpn/easy-rsa && rm -rfv /etc/openvpn/easy-rsa
 # Mapping
 # ---------------------------------------------------------------------------- #
 
-find map -type f | while read FILE; do
+find map -type f | while read -r FILE; do
   sudo mkdir -pv "$(dirname "${FILE/map/}")"
   sudo mv -v "${FILE}" "${FILE/map/}"
 done

--- a/platform/stage/deploy/vpn/remote.sh
+++ b/platform/stage/deploy/vpn/remote.sh
@@ -21,7 +21,7 @@ cd "$HOME"
 mv crl.pem ovpn_auth_database.yml tls-crypt.key /etc/openvpn/
 
 cd /etc/openvpn
-chown -R openvpn:openvpn *
+chown -R openvpn:openvpn ./*
 chmod 600 ovpn_auth_database.yml
 chmod 640 ./{crl.pem,tls-crypt.key,server.conf}
 mkdir -p /var/log/openvpn

--- a/scripts/stage/ip-of.sh
+++ b/scripts/stage/ip-of.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC2002
 cat "platform/stage/deployment/service_discovery.json" |
   jq -r ".[\"$PROGRAM_NAME\"].digitalocean[0].ipv4_address"


### PR DESCRIPTION
Changes

- Adding the enabling of exit-on-error mode (`set -e`) in the missing files
- Using `-r` for `read` command for its use for looping over output lines
- Using directives to disable following of imports
- Using directives to disable warnings for intended use of server side templating within heredocs
- Fixes ambiguous glob patten `*` to `./*` 
- Disabling shellcheck on suggesting using stdin/stdout redirection instead of `cat |` when contradicts with readability