### PR TITLE
Fixes the request logger reading body size from the wrong source

### DIFF
--- a/backend/internal/web/reception/summarizer/summarizer.go
+++ b/backend/internal/web/reception/summarizer/summarizer.go
@@ -63,7 +63,7 @@ func (s Summarizer) Pre(r *http.Request) string {
 }
 
 func (s Summarizer) Post(crw *captured.ResponseWriter, start time.Time) string {
-	return fmt.Sprintf("%s %s %s bytes",
+	return fmt.Sprintf("%s %s %s",
 		s.c.Magenta(crw.StatusRepresentation()),
 		s.c.Green(time.Since(start)),
 		s.c.Cyan(crw.SizeRepresentation()),

--- a/backend/internal/web/reception/summarizer/summarizer.go
+++ b/backend/internal/web/reception/summarizer/summarizer.go
@@ -66,6 +66,6 @@ func (s Summarizer) Post(crw *captured.ResponseWriter, start time.Time) string {
 	return fmt.Sprintf("%s %s %s bytes",
 		s.c.Magenta(crw.StatusRepresentation()),
 		s.c.Green(time.Since(start)),
-		s.c.Cyan(crw.Header().Get("Content-Length")),
+		s.c.Cyan(crw.SizeRepresentation()),
 	)
 }

--- a/backend/internal/web/reception/summarizer/summarizer.go
+++ b/backend/internal/web/reception/summarizer/summarizer.go
@@ -65,7 +65,7 @@ func (s Summarizer) Pre(r *http.Request) string {
 func (s Summarizer) Post(crw *captured.ResponseWriter, start time.Time) string {
 	return fmt.Sprintf("%s %s %s",
 		s.c.Magenta(crw.StatusRepresentation()),
-		s.c.Green(time.Since(start)),
+		s.c.Green(fmt.Sprintf("%dµs", time.Since(start).Microseconds())),
 		s.c.Cyan(crw.SizeRepresentation()),
 	)
 }

--- a/backend/internal/web/reception/summarizer/summarizer_test.go
+++ b/backend/internal/web/reception/summarizer/summarizer_test.go
@@ -1,0 +1,17 @@
+package summarizer
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"time"
+
+	"logbook/internal/web/reception/captured"
+)
+
+func ExampleSummarizer_post() {
+	s := New(false)
+	w := captured.New(httptest.NewRecorder())
+	w.Write([]byte("lorem ipsum dolor sit amet"))
+	fmt.Println(s.Post(w, time.Now().Add(-20*time.Millisecond)))
+	// Output: 200* 20000µs 26B
+}


### PR DESCRIPTION
**Mainly**

- fixes #62 

**Additionally**

- refines the elapsed time printing with fixed unit